### PR TITLE
Dual mode plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## [1.0.1](https://github.com/spoonconsulting/cordova-plugin-dual-mode-camera/compare/1.0.0...1.0.1) (2025-07-29)
+* **iOS:** Add Misssing declarations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## [1.0.1](https://github.com/spoonconsulting/cordova-plugin-dual-mode-camera/compare/1.0.0...1.0.1) (2025-07-29)
-* **iOS:** Add Misssing declarations
-
 ## [1.0.2](https://github.com/spoonconsulting/cordova-plugin-dual-mode-camera/compare/1.0.1...1.0.2) (2025-10-07)
 * **iOS:** Add video capture and bug fix
+
+## [1.0.1](https://github.com/spoonconsulting/cordova-plugin-dual-mode-camera/compare/1.0.0...1.0.1) (2025-07-29)
+* **iOS:** Add Misssing declarations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
 ## [1.0.1](https://github.com/spoonconsulting/cordova-plugin-dual-mode-camera/compare/1.0.0...1.0.1) (2025-07-29)
 * **iOS:** Add Misssing declarations
+
+## [1.0.2](https://github.com/spoonconsulting/cordova-plugin-dual-mode-camera/compare/1.0.1...1.0.2) (2025-10-07)
+* **iOS:** Add video capture and bug fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "cordova-plugin-dual-mode-camera",
-  "version": "1.0.0",
+  "name": "@spoonconsulting/cordova-plugin-dual-mode-camera",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cordova-plugin-dual-mode-camera",
-      "version": "1.0.0",
+      "name": "@spoonconsulting/cordova-plugin-dual-mode-camera",
+      "version": "1.0.1",
       "license": "ISC"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "cordova-plugin-dual-mode",
+  "name": "cordova-plugin-dual-mode-camera",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cordova-plugin-dual-mode",
+      "name": "cordova-plugin-dual-mode-camera",
       "version": "1.0.0",
       "license": "ISC"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spoonconsulting/cordova-plugin-dual-mode-camera",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spoonconsulting/cordova-plugin-dual-mode-camera",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cordova-plugin-dual-mode",
+  "name": "cordova-plugin-dual-mode-camera",
   "version": "1.0.0",
   "description": "A plugin with dual mode functionality allowing users to use both front and back camera at the same time and capture images",
   "keywords": [
@@ -15,8 +15,12 @@
   },
   "author": "Jatin Purmessur & Spoon Consulting Ltd",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/spoonconsulting/cordova-plugin-dual-mode-camera"
+  },
   "cordova": {
-    "id": "cordova-plugin-dual-mode",
+    "id": "cordova-plugin-dual-mode-camera",
     "platforms": [
       "android",
       "ios"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spoonconsulting/cordova-plugin-dual-mode-camera",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A plugin with dual mode functionality allowing users to use both front and back camera at the same time and capture images",
   "keywords": [
     "cordova",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cordova-plugin-dual-mode-camera",
+  "name": "@spoonconsulting/cordova-plugin-dual-mode-camera",
   "version": "1.0.0",
   "description": "A plugin with dual mode functionality allowing users to use both front and back camera at the same time and capture images",
   "keywords": [
@@ -20,7 +20,7 @@
     "url": "https://github.com/spoonconsulting/cordova-plugin-dual-mode-camera"
   },
   "cordova": {
-    "id": "cordova-plugin-dual-mode-camera",
+    "id": "@spoonconsulting/cordova-plugin-dual-mode-camera",
     "platforms": [
       "android",
       "ios"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spoonconsulting/cordova-plugin-dual-mode-camera",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A plugin with dual mode functionality allowing users to use both front and back camera at the same time and capture images",
   "keywords": [
     "cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin id="@spoonconsulting/cordova-plugin-dual-mode-camera" version="1.0.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="@spoonconsulting/cordova-plugin-dual-mode-camera" version="1.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 
     <name>cordova-plugin-dual-mode</name>
     <description>Cordova plugin that allows users to use both front and back camera at the same time</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,66 +1,56 @@
-
-
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin
-   xmlns="http://apache.org/cordova/ns/plugins/1.0" 
-   xmlns:android="http://schemas.android.com/apk/res/android"
-    id="cordova-plugin-dual-mode"
-    version="1.0.0">
 
-    <name>Dual Mode Plugin</name>
+<plugin id="@spoonconsulting/cordova-plugin-dual-mode-camera" version="1.0.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <name>cordova-plugin-dual-mode</name>
+    <description>Cordova plugin that allows users to use both front and back camera at the same time</description>
     <license>Apache 2.0</license>
+    <keywords>cordova, camera, dual-camera, front-camera, back-camera, video, media, plugin, ios, android, picture-in-picture, simultaneous-camera, multi-camera</keywords>
+    <repo>https://github.com/spoonconsulting/cordova-plugin-dual-mode-camera.git</repo>
+    <issue>https://github.com/spoonconsulting/cordova-plugin-dual-mode-camera/issues</issue>
 
-    <js-module src="www/dual-mode-plugin.js" name="DualModePlugin">
-        <clobbers target="dualCameraPreview"/>
+    <js-module src="www/DualCameraPreview.js" name="DualCameraPreview">
+    <clobbers target="DualCameraPreview" />
     </js-module>
 
     <platform name="android">
-        <config-file target="config.xml" parent="/*">
-            <feature name="DualModePlugin">
-                <param name="android-package" value="com.spoon.dualmode.DualModePlugin" />
-                 <param name="onload" value="true" />
-            </feature>
-        </config-file>
-        <config-file target="AndroidManifest.xml" parent="/manifest">
-            <uses-feature android:name="android.hardware.camera" android:required="true"/>
-            <uses-feature android:name="android.hardware.camera.autofocus" />
-            <uses-permission android:name="android.permission.CAMERA" />
-            <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-        </config-file>
-        <config-file target="res/values/strings.xml" parent="/*">
-            <string name="camera_error">This device does not support Camera2 API</string>
-        </config-file>
-        <source-file src="src/android/dual-mode-plugin.java" target-dir="src/com/dualmode/dualmodeplugin" />
+
     </platform>
 
     <platform name="ios">
-        <config-file target="config.xml" parent="/*">
-           <feature name="DualCameraPreview">
-                <param name="ios-package" value="DualCameraPreview" />
-            </feature>
+    <config-file target="config.xml" parent="/*">
+        <feature name="DualCameraPreview">
+            <param name="ios-package" value="DualCameraPreview" onload="true" />
+        </feature>
         </config-file>
 
         <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
-            <string>This App requires camera access to let you take the pictures that you would like to upload.</string>
+        <string>This App requires camera access to let you take the pictures that you would like to upload.</string>
         </config-file>
 
         <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
-            <string>This App requires access to your location to add GPS exif to captured images.</string>
-        </config-file>
+        <string>This App requires access to your location to add GPS exif to captured images.</string>
+    </config-file>
 
-        <framework src="AVFoundation.framework" />
-        <framework src="UIKit.framework" />
-        <framework src="ImageIO.framework" weak="true" />
-        <framework src="MobileCoreServices.framework" />
-        <framework src="CoreLocation.framework" />
-        <framework src="CoreGraphics.framework" />
-        <framework src="AssetsLibrary.framework" />
-        <framework src="CoreGraphics.framework" />
-        <framework src="CoreImage.framework" />
-        <framework src="OpenGLES.framework" />
-        <framework src="GLKit.framework" />
-        <framework src="CoreVideo.framework" />
-        <framework src="QuartzCore.framework"/>
-    </platform>
+    <source-file src="src/ios/VideoMixerShader.metal" />
+    <source-file src="src/ios/DualCameraPreview.swift" />
+    <source-file src="src/ios/DualCameraSessionManager.swift" />
+    <source-file src="src/ios/DualCameraRenderController.swift" />
+    <source-file src="src/ios/VideoRecorder.swift" />
+    <source-file src="src/ios/VideoMixer.swift" />
+
+    <framework src="ImageIO.framework" weak="true" />
+    <framework src="MobileCoreServices.framework" />
+    <framework src="CoreLocation.framework" />
+    <framework src="CoreGraphics.framework" />
+    <framework src="AssetsLibrary.framework" />
+    <framework src="CoreGraphics.framework" />
+    <framework src="CoreImage.framework" />
+    <framework src="OpenGLES.framework" />
+    <framework src="GLKit.framework" />
+    <framework src="CoreVideo.framework" />
+    <framework src="QuartzCore.framework"/>
+  </platform>
+
 </plugin>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin id="@spoonconsulting/cordova-plugin-dual-mode-camera" version="1.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="@spoonconsulting/cordova-plugin-dual-mode-camera" version="1.0.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 
     <name>cordova-plugin-dual-mode</name>
     <description>Cordova plugin that allows users to use both front and back camera at the same time</description>

--- a/src/ios/DualCameraPreview.swift
+++ b/src/ios/DualCameraPreview.swift
@@ -25,8 +25,8 @@ import CoreLocation
         self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
     }
 
-    @objc(enableDualMode:)
-    func enableDualMode(_ command: CDVInvokedUrlCommand) {
+    @objc(enable:)
+    func enable(_ command: CDVInvokedUrlCommand) {
         if isSessionEnabled {
             let pluginResult = CDVPluginResult(status: .error, messageAs: "Dual mode already enabled")
             self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
@@ -92,8 +92,8 @@ import CoreLocation
         }
     }
 
-    @objc(disableDualMode:)
-    func disableDualMode(_ command: CDVInvokedUrlCommand) {
+    @objc(disable:)
+    func disable(_ command: CDVInvokedUrlCommand) {
         sessionQueue.async { [weak self] in
             guard let self = self else { return }
 
@@ -190,8 +190,8 @@ import CoreLocation
         return gps
     }
 
-    @objc(captureDual:)
-    func captureDual(_ command: CDVInvokedUrlCommand) {
+    @objc(capture:)
+    func capture(_ command: CDVInvokedUrlCommand) {
         guard isSessionEnabled,
               let sessionManager = sessionManager,
               sessionManager.isReady() else {
@@ -200,7 +200,7 @@ import CoreLocation
             return
         }
 
-        self.captureDualImagesWithCompletion {
+        self.captureImagesWithCompletion {
             [weak self] mergedImage, error in
             guard let self = self else { return }
             
@@ -281,7 +281,7 @@ import CoreLocation
             }
     }
 
-    @objc func captureDualImagesWithCompletion(_ completion: @escaping (UIImage?, Error?) -> Void) {
+    @objc func captureImagesWithCompletion(_ completion: @escaping (UIImage?, Error?) -> Void) {
         self.captureCompletion = completion
         self.latestFrontImage = nil
         self.latestBackImage = nil
@@ -418,8 +418,8 @@ import CoreLocation
         self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
     }
     
-    @objc(startVideoCaptureDual:)
-     func startVideoCaptureDual(_ command: CDVInvokedUrlCommand) {
+    @objc(startVideoCapture:)
+     func startVideoCapture(_ command: CDVInvokedUrlCommand) {
         guard let options = command.arguments.first as? [String: Any] else {
             let errorResult = CDVPluginResult(status: .error, messageAs: "Missing options")!
             self.commandDelegate.send(errorResult, callbackId: command.callbackId)
@@ -457,7 +457,7 @@ import CoreLocation
         sessionQueue.async { [weak self] in
             guard let self = self else { return }
 
-            self.startDualVideoRecordingWithAudio(recordWithAudio, duration: videoDurationMs) { [weak self] (videoPath, thumbnailPath, error) in
+            self.startVideoRecordingWithAudio(recordWithAudio, duration: videoDurationMs) { [weak self] (videoPath, thumbnailPath, error) in
                 guard let self = self else { return }
                 if let error = error {
                     let errorResult = CDVPluginResult(status: .error, messageAs: error.localizedDescription)!
@@ -474,7 +474,7 @@ import CoreLocation
         }
     }
 
-    @objc func startDualVideoRecordingWithAudio(
+    @objc func startVideoRecordingWithAudio(
         _ recordWithAudio: Bool,
         duration: Int,
         completion: @escaping (String, String?, Error?) -> Void
@@ -530,8 +530,8 @@ import CoreLocation
         }
     }
     
-    @objc(stopVideoCaptureDual:)
-    func stopVideoCaptureDual(_ command: CDVInvokedUrlCommand) {
+    @objc(stopVideoCapture:)
+    func stopVideoCapture(_ command: CDVInvokedUrlCommand) {
         sessionQueue.async { [weak self] in
             guard let self = self else { return }
 
@@ -577,15 +577,15 @@ import CoreLocation
             self.recordingCompletion = nil
 
             if let error = err {
-                self.dualModeRecordingDidFail(withError: error)
+                self.recordingDidFail(withError: error)
             } else {
-                self.dualModeRecordingDidFinish(withVideoPath: path, thumbnailPath: thumb)
+                self.recordingDidFinish(withVideoPath: path, thumbnailPath: thumb)
             }
             self.videoRecorder = nil
         }
     }
 
-    @objc func dualModeRecordingDidFinish(withVideoPath videoPath: String, thumbnailPath: String?) {
+    @objc func recordingDidFinish(withVideoPath videoPath: String, thumbnailPath: String?) {
         let result: [String: Any] = [
             "nativePath": videoPath,
             "thumbnail": thumbnailPath ?? NSNull()
@@ -601,7 +601,7 @@ import CoreLocation
         }
     }
 
-    @objc func dualModeRecordingDidFail(withError error: Error) {
+    @objc func recordingDidFail(withError error: Error) {
         let pluginResult = CDVPluginResult(status: .error, messageAs: error.localizedDescription)!
         
         if let callbackId = self.videoCallbackContext?.callbackId {

--- a/src/ios/DualCameraPreview.swift
+++ b/src/ios/DualCameraPreview.swift
@@ -1,0 +1,669 @@
+import UIKit
+import AVFoundation
+import CoreLocation
+
+@objc(DualCameraPreview) class DualCameraPreview: CDVPlugin, DualCameraSessionManagerDelegate {
+    private var sessionManager: DualCameraSessionManager?
+    private var previewBuilder: DualCameraRenderController?
+    private var latestBackImage: UIImage?
+    private var latestFrontImage: UIImage?
+    private var captureCompletion: ((UIImage?, Error?) -> Void)?
+    private var currentLocation: CLLocation?
+    var videoCallbackContext: CDVInvokedUrlCommand?
+    private var videoRecorder: VideoRecorder?
+    private var recordingCompletion: ((String, String?, Error?) -> Void)?
+    private var recordingTimer: Timer?
+     private let sessionQueue = DispatchQueue(label: "dual.camera.session.queue", qos: .userInitiated)
+    private let stateLock = NSLock()
+    private var _isSessionEnabled = false
+    private var _isRecording = false
+
+    @objc(deviceSupportDualMode:)
+    func deviceSupportDualMode(command: CDVInvokedUrlCommand) {
+        let supportsMultiCam = AVCaptureMultiCamSession.isMultiCamSupported
+        let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: supportsMultiCam)
+        self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+    }
+
+    @objc(initVideoCallback:)
+    func initVideoCallback(_ command: CDVInvokedUrlCommand) {
+        self.videoCallbackContext = command
+        let data: [String: Any] = ["videoCallbackInitialized": true]
+        
+        let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: data)
+        pluginResult?.setKeepCallbackAs(true)
+        self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+    }
+
+    @objc(enableDualMode:)
+    func enableDualMode(_ command: CDVInvokedUrlCommand) {
+
+        if isSessionEnabled {
+            let pluginResult = CDVPluginResult(status: .error, messageAs: "Dual mode already enabled")
+            self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+            return
+        }
+
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+            
+
+            guard !self.isSessionEnabled else {
+                DispatchQueue.main.async {
+                    let pluginResult = CDVPluginResult(status: .error, messageAs: "Dual mode already enabled")
+                    self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+                }
+                return
+            }
+
+            self.sessionManager = DualCameraSessionManager()
+            self.previewBuilder = DualCameraRenderController()
+
+            guard let sessionManager = self.sessionManager, let previewBuilder = self.previewBuilder else {
+                DispatchQueue.main.async {
+                    let pluginResult = CDVPluginResult(status: .error, messageAs: "Failed to initialize session.")
+                    self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+                }
+                return
+            }
+
+            sessionManager.setupSession(delegate: self) { [weak self] success in
+                guard let self = self else { return }
+
+                if !success {
+                    DispatchQueue.main.async {
+                        let pluginResult = CDVPluginResult(status: .error, messageAs: "Failed to setup dual camera session")
+                        self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+                    }
+                    return
+                }
+
+                DispatchQueue.main.async {
+                    NotificationCenter.default.addObserver(
+                        self,
+                        selector: #selector(self.handleOrientationChange),
+                        name: UIDevice.orientationDidChangeNotification,
+                        object: nil
+                    )
+
+                    if let container = self.webView.superview {
+                        previewBuilder.setupPreview(on: container, session: sessionManager.session, sessionManager: sessionManager, dualCameraPreview: self)
+                    } else {
+                        let pluginResult = CDVPluginResult(status: .error, messageAs: "Container view not set")
+                        self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+                        return
+                    }
+
+                    sessionManager.startSession()
+                    self.isSessionEnabled = true
+                    
+                    let pluginResult = CDVPluginResult(status: .ok, messageAs: "Dual mode enabled successfully")
+                    self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+                }
+            }
+        }
+    }
+
+    @objc(disableDualMode:)
+    func disableDualMode(_ command: CDVInvokedUrlCommand) {
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            guard self.isSessionEnabled else {
+                DispatchQueue.main.async {
+                    let pluginResult = CDVPluginResult(status: .ok, messageAs: "Dual mode already disabled")
+                    self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+                }
+                return
+            }
+
+            if self.isRecording {
+                self.stopDualVideoRecording()
+            }
+
+            if let sessionManager = self.sessionManager,
+               sessionManager.isReady() {
+                sessionManager.stopSession()
+                // Ensure video mixer orientation is unlocked
+                sessionManager.videoMixer.unlockOrientation()
+            }
+
+            DispatchQueue.main.async {
+                NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    self.previewBuilder?.teardownPreview()
+                    self.sessionManager = nil
+                    self.previewBuilder = nil
+                    self.isSessionEnabled = false
+                    let pluginResult = CDVPluginResult(status: .ok, messageAs: "Dual mode disabled successfully")
+                    self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+                }
+            }
+        }
+    }
+
+    func getGPSDictionaryForLocation() -> [String: Any]? {
+        guard let location = currentLocation else { return nil }
+        var gps: [String: Any] = [:]
+        
+        // GPS tag version
+        gps[kCGImagePropertyGPSVersion as String] = "2.2.0.0"
+        
+        // Time and date must be provided as strings, not as an NSDate object
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SSSSSS"
+        formatter.timeZone = TimeZone(abbreviation: "UTC")
+        gps[kCGImagePropertyGPSTimeStamp as String] = formatter.string(from: location.timestamp)
+        formatter.dateFormat = "yyyy:MM:dd"
+        gps[kCGImagePropertyGPSDateStamp as String] = formatter.string(from: location.timestamp)
+        
+        // Latitude
+        var latitude = location.coordinate.latitude
+        if latitude < 0 {
+            latitude = -latitude
+            gps[kCGImagePropertyGPSLatitudeRef as String] = "S"
+        } else {
+            gps[kCGImagePropertyGPSLatitudeRef as String] = "N"
+        }
+        gps[kCGImagePropertyGPSLatitude as String] = latitude
+        
+        // Longitude
+        var longitude = location.coordinate.longitude
+        if longitude < 0 {
+            longitude = -longitude
+            gps[kCGImagePropertyGPSLongitudeRef as String] = "W"
+        } else {
+            gps[kCGImagePropertyGPSLongitudeRef as String] = "E"
+        }
+        gps[kCGImagePropertyGPSLongitude as String] = longitude
+        
+        // Altitude
+        let altitude = location.altitude
+        if !altitude.isNaN {
+            if altitude < 0 {
+                gps[kCGImagePropertyGPSAltitudeRef as String] = "1"
+            } else {
+                gps[kCGImagePropertyGPSAltitudeRef as String] = "0"
+            }
+            gps[kCGImagePropertyGPSAltitude as String] = altitude
+        }
+        
+        if location.speed >= 0 {
+            gps[kCGImagePropertyGPSSpeedRef as String] = "K"
+            gps[kCGImagePropertyGPSSpeed as String] = location.speed * 3.6
+        }
+        
+        // Heading
+        if location.course >= 0 {
+            gps[kCGImagePropertyGPSTrackRef as String] = "T"
+            gps[kCGImagePropertyGPSTrack as String] = location.course
+        }
+        
+        return gps
+    }
+
+    @objc(captureDual:)
+    func captureDual(_ command: CDVInvokedUrlCommand) {
+        guard isSessionEnabled,
+              let sessionManager = sessionManager,
+              sessionManager.isReady() else {
+            let errorResult = CDVPluginResult(status: .error, messageAs: "Session not ready")
+            self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+            return
+        }
+
+        self.captureDualImagesWithCompletion {
+            [weak self] mergedImage, error in
+            guard let self = self else { return }
+            
+            if let error = error {
+                let errorResult = CDVPluginResult(status: .error, messageAs: error.localizedDescription)
+                self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+                return
+            }
+            guard let mergedImage = mergedImage else {
+                let errorResult = CDVPluginResult(status: .error, messageAs: "Failed to capture image")
+                self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+                return
+            }
+            
+            guard let imageData = mergedImage.jpegData(compressionQuality: 0.9) else {
+                let errorResult = CDVPluginResult(status: .error, messageAs: "Failed to convert merged image")
+                self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+                return
+            }
+            
+            let cfData = imageData as CFData
+            guard let imageSource = CGImageSourceCreateWithData(cfData, nil) else {
+                let errorResult = CDVPluginResult(status: .error, messageAs: "Failed to create image source")
+                self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+                return
+            }
+            
+            guard let metaDict = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) else {
+                let errorResult = CDVPluginResult(status: .error, messageAs: "Failed to get image properties")
+                self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+                return
+            }
+            let mutableDict = NSMutableDictionary(dictionary: metaDict)
+            
+            if let gpsData = self.getGPSDictionaryForLocation() {
+                mutableDict[kCGImagePropertyGPSDictionary as String] = gpsData
+            }
+            
+            let paths = NSSearchPathForDirectoriesInDomains(.libraryDirectory, .userDomainMask, true)
+            guard let libraryDirectory = paths.first else {
+                let errorResult = CDVPluginResult(status: .error, messageAs: "Library directory not found")
+                self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+                return
+            }
+            let noCloudPath = (libraryDirectory as NSString).appendingPathComponent("NoCloud")
+            let uniqueFileName = UUID().uuidString + ".jpg"
+            let fullPath = (noCloudPath as NSString).appendingPathComponent(uniqueFileName)
+            let dataPath = "file://" + fullPath
+            
+            guard let url = URL(string: dataPath) else {
+                let errorResult = CDVPluginResult(status: .error, messageAs: "Invalid file URL")
+                self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+                return
+            }
+            
+            guard let uti = CGImageSourceGetType(imageSource) else {
+                let errorResult = CDVPluginResult(status: .error, messageAs: "Failed to get image UTI")
+                self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+                return
+            }
+            
+            guard let destination = CGImageDestinationCreateWithURL(url as CFURL, uti, 1, nil) else {
+                let errorResult = CDVPluginResult(status: .error, messageAs: "Failed to create image destination")
+                self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+                return
+            }
+            
+            CGImageDestinationAddImageFromSource(destination, imageSource, 0, mutableDict)
+            
+            guard CGImageDestinationFinalize(destination) else {
+                let errorResult = CDVPluginResult(status: .error, messageAs: "Failed to finalize image destination")
+                self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+                return
+            }
+
+            let successResult = CDVPluginResult(status: .ok, messageAs: dataPath)
+            self.commandDelegate.send(successResult, callbackId: command.callbackId)
+            }
+    }
+
+    @objc func captureDualImagesWithCompletion(_ completion: @escaping (UIImage?, Error?) -> Void) {
+        self.captureCompletion = completion
+        self.latestFrontImage = nil
+        self.latestBackImage = nil
+    }
+
+    func sessionManager(_ manager: DualCameraSessionManager, didOutput sampleBuffer: CMSampleBuffer, from output: AVCaptureOutput) {
+        if self.captureCompletion != nil {
+           guard let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+           let ciImage = CIImage(cvImageBuffer: imageBuffer)
+           let context = CIContext()
+           guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else { return }
+
+           let orientation = getImageOrientationForCapture(connection: nil)
+           let image = UIImage(cgImage: cgImage, scale: UIScreen.main.scale, orientation: orientation)
+
+           if output == manager.backOutput {
+               latestBackImage = image
+           } else if output == manager.frontOutput {
+               latestFrontImage = image
+           }
+
+           if let front = latestFrontImage, let back = latestBackImage, let completion = captureCompletion {
+               let merged = mergeImages(background: back, overlay: front)
+               let finalImage: UIImage
+               if !UIDevice.current.orientation.isLandscape {
+                   finalImage = rotateImageToPortrait(merged)
+               } else {
+                   finalImage = merged
+               }
+               DispatchQueue.main.async {
+                   completion(finalImage, nil)
+                   self.captureCompletion = nil
+                   self.latestBackImage = nil
+                   self.latestFrontImage = nil
+               }
+            }
+        }
+    }
+
+    private func rotateImageToPortrait(_ image: UIImage) -> UIImage {
+        let size = CGSize(width: image.size.height, height: image.size.width)
+        UIGraphicsBeginImageContextWithOptions(size, false, image.scale)
+        guard let context = UIGraphicsGetCurrentContext() else { return image }
+        context.translateBy(x: 0, y: size.height)
+        context.rotate(by: -.pi / 2)
+        image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+        let rotatedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return rotatedImage ?? image
+    }
+
+    private func imageOrientation(for videoOrientation: AVCaptureVideoOrientation) -> UIImage.Orientation {
+        switch videoOrientation {
+        case .portrait:
+            return .up
+        case .portraitUpsideDown:
+            return .down
+        case .landscapeRight:
+            return .right
+        case .landscapeLeft:
+            return .left
+        @unknown default:
+            return .up
+        }
+    }
+
+    private func getImageOrientationForCapture(connection: AVCaptureConnection?) -> UIImage.Orientation {
+        let deviceOrientation = UIDevice.current.orientation
+        let isLandscape = deviceOrientation == .landscapeLeft || deviceOrientation == .landscapeRight
+        
+        if !isLandscape {
+            if let connection = connection {
+                return imageOrientation(for: connection.videoOrientation)
+            } else {
+                return .right
+            }
+        }
+            
+        switch deviceOrientation {
+        case .landscapeLeft:
+            return .up
+        case .landscapeRight:
+            return .down
+        default:
+            return .up
+        }
+    }
+
+    private func getImageOrientationFromConnection(_ connection: AVCaptureConnection) -> UIImage.Orientation {
+        return imageOrientation(for: connection.videoOrientation)
+    }
+
+    func mergeImages(background: UIImage, overlay: UIImage) -> UIImage {
+        let size = background.size
+        let deviceOrientation = UIDevice.current.orientation
+        let isLandscape = deviceOrientation == .landscapeLeft || deviceOrientation == .landscapeRight
+        let padding: CGFloat = 16
+        var overlayWidth: CGFloat
+        var overlayHeight: CGFloat
+        var overlayRect: CGRect
+
+        overlayWidth = size.width * 0.3
+        overlayHeight = overlay.size.height * (overlayWidth / overlay.size.width)
+
+        if isLandscape {
+            overlayRect = CGRect(x: padding,
+                                 y: padding,
+                                 width: overlayWidth,
+                                 height: overlayHeight)
+        } else {
+            overlayRect = CGRect(x: size.width - overlayWidth - padding,
+                                 y: padding,
+                                 width: overlayWidth,
+                                 height: overlayHeight)
+        }
+
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        background.draw(in: CGRect(origin: .zero, size: size))
+        overlay.draw(in: overlayRect)
+        let merged = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return merged ?? background
+    }
+    
+    @objc(startVideoCaptureDual:)
+     func startVideoCaptureDual(_ command: CDVInvokedUrlCommand) {
+        guard let options = command.arguments.first as? [String: Any] else {
+            let errorResult = CDVPluginResult(status: .error, messageAs: "Missing options")!
+            self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+            return
+        }
+        
+        let recordWithAudio = options["recordWithAudio"] as? Bool ?? true
+        let videoDurationMs = options["videoDurationMs"] as? Int ?? 3000
+        
+        guard isSessionEnabled,
+              let sessionManager = self.sessionManager,
+              sessionManager.isReady() else {
+            let errorResult = CDVPluginResult(status: .error, messageAs: "Dual mode not enabled or session not ready")!
+            self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+            return
+        }
+
+        if isRecording {
+            let errorResult = CDVPluginResult(status: .error, messageAs: "Recording already in progress")!
+            self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+            return
+        }
+        
+        if let callbackId = self.videoCallbackContext?.callbackId {
+            let event: [String: Any] = ["recording": true]
+            let recordingStarted = CDVPluginResult(status: .ok, messageAs: event)!
+            recordingStarted.setKeepCallbackAs(true)
+            self.commandDelegate.send(recordingStarted, callbackId: callbackId)
+        } else {
+            let errorResult = CDVPluginResult(status: .error, messageAs: "Video callback context not initialized")!
+            self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+            return
+        }
+        
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            self.startDualVideoRecordingWithAudio(recordWithAudio, duration: videoDurationMs) { [weak self] (videoPath, thumbnailPath, error) in
+                guard let self = self else { return }
+                if let error = error {
+                    let errorResult = CDVPluginResult(status: .error, messageAs: error.localizedDescription)!
+                    self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+                } else {
+                    let result: [String: Any] = [
+                        "nativePath": videoPath,
+                        "thumbnail": thumbnailPath ?? NSNull()
+                    ]
+                    let pluginResult = CDVPluginResult(status: .ok, messageAs: result)!
+                    self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+                }
+            }
+        }
+    }
+
+    @objc func startDualVideoRecordingWithAudio(
+        _ recordWithAudio: Bool,
+        duration: Int,
+        completion: @escaping (String, String?, Error?) -> Void
+    ) {
+        guard !isRecording else {
+            completion("", nil, NSError(domain: "DualCamera", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Already recording"]))
+            return
+        }
+
+        self.videoRecorder = VideoRecorder()
+        self.recordingCompletion = completion
+        self.isRecording = true
+
+        let recordingOrientation = getValidRecordingOrientation()
+        self.videoRecorder?.startWriting(audioEnabled: recordWithAudio, recordingOrientation: recordingOrientation) { [weak self] error in
+            guard let self = self else { return }
+
+            if let error = error {
+                self.isRecording = false
+                completion("", nil, error)
+                return
+            }
+
+            if let recorder = self.videoRecorder,
+               let sessionManager = self.sessionManager,
+               sessionManager.isReady() {
+                sessionManager.startRecording(with: recorder)
+            }
+
+            let durationInSeconds = TimeInterval(duration) / 1000.0
+            DispatchQueue.main.async {
+                self.recordingTimer = Timer.scheduledTimer(
+                    timeInterval: durationInSeconds,
+                    target: self,
+                    selector: #selector(self.stopVideoCaptureDualTimer),
+                    userInfo: nil,
+                    repeats: false
+                )
+            }
+        }
+    }
+    
+    private func getValidRecordingOrientation() -> UIDeviceOrientation {
+        let currentOrientation = UIDevice.current.orientation
+        
+        switch currentOrientation {
+        case .portrait, .portraitUpsideDown, .landscapeLeft, .landscapeRight:
+            return currentOrientation
+        case .faceUp, .faceDown, .unknown:
+            return .portrait
+        @unknown default:
+            return .portrait
+        }
+    }
+    
+    @objc(stopVideoCaptureDual:)
+    func stopVideoCaptureDual(_ command: CDVInvokedUrlCommand) {
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            if self.isSessionEnabled && self.isRecording {
+                self.stopDualVideoRecording()
+                DispatchQueue.main.async {
+                    let result = CDVPluginResult(status: .ok)!
+                    self.commandDelegate.send(result, callbackId: command.callbackId)
+                }
+            } else {
+                DispatchQueue.main.async {
+                    let errorResult = CDVPluginResult(status: .error, messageAs: "Not recording or dual mode not enabled")!
+                    self.commandDelegate.send(errorResult, callbackId: command.callbackId)
+                }
+            }
+        }
+    }
+    
+    @objc func stopVideoCaptureDualTimer() {
+        sessionQueue.async { [weak self] in
+            self?.stopDualVideoRecording()
+        }
+    }
+    
+    func stopDualVideoRecording() {
+        guard isRecording else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.recordingTimer?.invalidate()
+            self?.recordingTimer = nil
+        }
+
+        if let sessionManager = sessionManager,
+           sessionManager.isReady() {
+            sessionManager.stopRecording()
+        }
+
+        self.videoRecorder?.stopWriting { [weak self] path, thumb, err in
+            guard let self = self else { return }
+
+            self.isRecording = false
+            self.recordingCompletion?(path, thumb, err)
+            self.recordingCompletion = nil
+
+            if let error = err {
+                self.dualModeRecordingDidFail(withError: error)
+            } else {
+                self.dualModeRecordingDidFinish(withVideoPath: path, thumbnailPath: thumb)
+            }
+            self.videoRecorder = nil
+        }
+    }
+
+    @objc func dualModeRecordingDidFinish(withVideoPath videoPath: String, thumbnailPath: String?) {
+        let result: [String: Any] = [
+            "nativePath": videoPath,
+            "thumbnail": thumbnailPath ?? NSNull()
+        ]
+        
+        let pluginResult = CDVPluginResult(status: .ok, messageAs: result)!
+        pluginResult.setKeepCallbackAs(true)
+        
+        if let callbackId = self.videoCallbackContext?.callbackId {
+            self.commandDelegate.send(pluginResult, callbackId: callbackId)
+        } else {
+            print("videoCallbackContext not set; cannot send result.")
+        }
+    }
+
+    @objc func dualModeRecordingDidFail(withError error: Error) {
+        let pluginResult = CDVPluginResult(status: .error, messageAs: error.localizedDescription)!
+        
+        if let callbackId = self.videoCallbackContext?.callbackId {
+            self.commandDelegate.send(pluginResult, callbackId: callbackId)
+        } else {
+            print("videoCallbackContext not set; cannot send error.")
+        }
+    }
+    
+    @objc private func handleOrientationChange() {
+        guard isSessionEnabled,
+              let sessionManager = sessionManager,
+              sessionManager.isReady() else {
+            return
+        }
+
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            if self.isRecording {
+                let isLandscape = UIDevice.current.orientation.isLandscape
+                if isLandscape {
+                    sessionManager.videoMixer.pipFrame = CGRect(x: 0.03, y: 0.03, width: 0.25, height: 0.25)
+                } else {
+                    sessionManager.videoMixer.pipFrame = CGRect(x: 0.05, y: 0.05, width: 0.3, height: 0.3)
+                }
+            }
+        }
+    }
+
+    private var isSessionEnabled: Bool {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _isSessionEnabled
+        }
+
+        set {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            _isSessionEnabled = newValue
+        }
+    }
+    
+    private var isRecording: Bool {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _isRecording
+        }
+
+        set {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            _isRecording = newValue
+        }
+    }
+    
+    var isCurrentlyRecording: Bool {
+        return isRecording
+    }
+}

--- a/src/ios/DualCameraPreview.swift
+++ b/src/ios/DualCameraPreview.swift
@@ -13,7 +13,7 @@ import CoreLocation
     private var videoRecorder: VideoRecorder?
     private var recordingCompletion: ((String, String?, Error?) -> Void)?
     private var recordingTimer: Timer?
-     private let sessionQueue = DispatchQueue(label: "dual.camera.session.queue", qos: .userInitiated)
+    private let sessionQueue = DispatchQueue(label: "dual.camera.session.queue", qos: .userInitiated)
     private let stateLock = NSLock()
     private var _isSessionEnabled = false
     private var _isRecording = false
@@ -25,19 +25,8 @@ import CoreLocation
         self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
     }
 
-    @objc(initVideoCallback:)
-    func initVideoCallback(_ command: CDVInvokedUrlCommand) {
-        self.videoCallbackContext = command
-        let data: [String: Any] = ["videoCallbackInitialized": true]
-        
-        let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: data)
-        pluginResult?.setKeepCallbackAs(true)
-        self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
-    }
-
     @objc(enableDualMode:)
     func enableDualMode(_ command: CDVInvokedUrlCommand) {
-
         if isSessionEnabled {
             let pluginResult = CDVPluginResult(status: .error, messageAs: "Dual mode already enabled")
             self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
@@ -46,7 +35,6 @@ import CoreLocation
 
         sessionQueue.async { [weak self] in
             guard let self = self else { return }
-            
 
             guard !self.isSessionEnabled else {
                 DispatchQueue.main.async {
@@ -124,7 +112,6 @@ import CoreLocation
             if let sessionManager = self.sessionManager,
                sessionManager.isReady() {
                 sessionManager.stopSession()
-                // Ensure video mixer orientation is unlocked
                 sessionManager.videoMixer.unlockOrientation()
             }
 
@@ -419,6 +406,16 @@ import CoreLocation
         UIGraphicsEndImageContext()
 
         return merged ?? background
+    }
+
+    @objc(initVideoCallback:)
+    func initVideoCallback(_ command: CDVInvokedUrlCommand) {
+        self.videoCallbackContext = command
+        let data: [String: Any] = ["videoCallbackInitialized": true]
+        
+        let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: data)
+        pluginResult?.setKeepCallbackAs(true)
+        self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
     }
     
     @objc(startVideoCaptureDual:)

--- a/src/ios/DualCameraRenderController.swift
+++ b/src/ios/DualCameraRenderController.swift
@@ -41,7 +41,6 @@ class DualCameraRenderController {
     }
 
     @objc private func orientationChanged() {
-        // Don't change preview orientation while recording
         if let dualCameraPreview = dualCameraPreview, dualCameraPreview.isCurrentlyRecording {
             return
         }
@@ -83,7 +82,6 @@ class DualCameraRenderController {
     }
     
     private func updateFrontCameraOrientation() {
-        // Don't change camera orientation while recording
         if let dualCameraPreview = dualCameraPreview, dualCameraPreview.isCurrentlyRecording {
             return
         }

--- a/src/ios/DualCameraRenderController.swift
+++ b/src/ios/DualCameraRenderController.swift
@@ -1,0 +1,178 @@
+import UIKit
+import AVFoundation
+
+class DualCameraRenderController {
+    private var backPreviewLayer: AVCaptureVideoPreviewLayer?
+    private var frontPreviewLayer: AVCaptureVideoPreviewLayer?
+    private var pipView: UIView?
+    private var containerView: UIView?
+    private var session: AVCaptureMultiCamSession?
+    private var sessionManager: DualCameraSessionManager?
+    private weak var dualCameraPreview: DualCameraPreview?
+
+    func setupPreview(on view: UIView, session: AVCaptureMultiCamSession, sessionManager: DualCameraSessionManager, dualCameraPreview: DualCameraPreview) {
+        self.containerView = view
+        self.session = session
+        self.sessionManager = sessionManager
+        self.dualCameraPreview = dualCameraPreview
+        setupBackPreviewLayer(on: view, session: session)
+        setupPiPView(on: view)
+        setupFrontPreviewLayer(session: session)
+        updatePreviewForCurrentOrientation()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(orientationChanged),
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil
+        )
+    }
+
+    func teardownPreview() {
+        NotificationCenter.default.removeObserver(self)
+        
+        backPreviewLayer?.removeFromSuperlayer()
+        backPreviewLayer = nil
+        frontPreviewLayer?.removeFromSuperlayer()
+        frontPreviewLayer = nil
+        pipView?.removeFromSuperview()
+        pipView = nil
+        containerView = nil
+        session = nil
+    }
+
+    @objc private func orientationChanged() {
+        // Don't change preview orientation while recording
+        if let dualCameraPreview = dualCameraPreview, dualCameraPreview.isCurrentlyRecording {
+            return
+        }
+        
+        guard let containerView = containerView else { return }
+        
+        DispatchQueue.main.async {
+            self.updatePreviewForCurrentOrientation()
+        }
+    }
+    
+    private func updatePreviewForCurrentOrientation() {
+        guard let containerView = containerView,
+              let pipView = pipView,
+              let frontPreviewLayer = frontPreviewLayer else { return }
+        
+        let orientation = UIDevice.current.orientation
+        let isLandscape = orientation == .landscapeLeft || orientation == .landscapeRight
+        
+        if isLandscape {
+            let pipWidth: CGFloat = 240
+            let pipHeight: CGFloat = 160
+            let pipX: CGFloat = 20
+            let pipY: CGFloat = 15
+            
+            pipView.frame = CGRect(x: pipX, y: pipY, width: pipWidth, height: pipHeight)
+        } else {
+            let pipWidth: CGFloat = 160
+            let pipHeight: CGFloat = 240
+            let pipX: CGFloat = 16
+            let pipY: CGFloat = 60
+            
+            pipView.frame = CGRect(x: pipX, y: pipY, width: pipWidth, height: pipHeight)
+        }
+        
+        frontPreviewLayer.frame = pipView.bounds
+        backPreviewLayer?.frame = containerView.bounds
+        updateFrontCameraOrientation()
+    }
+    
+    private func updateFrontCameraOrientation() {
+        // Don't change camera orientation while recording
+        if let dualCameraPreview = dualCameraPreview, dualCameraPreview.isCurrentlyRecording {
+            return
+        }
+        
+        guard let session = session else { return }
+        
+        let orientation = UIDevice.current.orientation
+        let videoOrientation: AVCaptureVideoOrientation
+        
+        switch orientation {
+        case .portrait:
+            videoOrientation = .portrait
+        case .portraitUpsideDown:
+            videoOrientation = .portraitUpsideDown
+        case .landscapeLeft:
+            videoOrientation = .landscapeRight
+        case .landscapeRight:
+            videoOrientation = .landscapeLeft
+        default:
+            videoOrientation = .portrait
+        }
+        
+        sessionManager?.updateVideoOrientation(videoOrientation)
+        if let frontConnection = frontPreviewLayer?.connection {
+            if frontConnection.isVideoOrientationSupported {
+                frontConnection.videoOrientation = videoOrientation
+            }
+        }
+        
+        if let backConnection = backPreviewLayer?.connection {
+            if backConnection.isVideoOrientationSupported {
+                backConnection.videoOrientation = videoOrientation
+            }
+        }
+    }
+
+    private func setupBackPreviewLayer(on view: UIView, session: AVCaptureMultiCamSession) {
+        backPreviewLayer = AVCaptureVideoPreviewLayer(session: session)
+        backPreviewLayer?.videoGravity = .resizeAspectFill
+        backPreviewLayer?.frame = view.bounds
+
+        if let backLayer = backPreviewLayer {
+            if let webViewLayer = view.subviews.first(where: { $0 is WKWebView || $0 is UIWebView })?.layer {
+                view.layer.insertSublayer(backLayer, below: webViewLayer)
+            } else {
+                view.layer.insertSublayer(backLayer, at: 0)
+            }
+        }
+    }
+
+    private func setupPiPView(on view: UIView) {
+        let orientation = UIDevice.current.orientation
+        let isLandscape = orientation == .landscapeLeft || orientation == .landscapeRight
+        
+        let pipWidth: CGFloat
+        let pipHeight: CGFloat
+        let pipX: CGFloat = 16
+        let pipY: CGFloat = 60
+        
+        if isLandscape {
+            pipWidth = 240
+            pipHeight = 160
+        } else {
+            pipWidth = 160
+            pipHeight = 240
+        }
+
+        let pipView = UIView(frame: CGRect(x: pipX, y: pipY, width: pipWidth, height: pipHeight))
+        self.pipView = pipView
+        pipView.layer.cornerRadius = 12
+        pipView.clipsToBounds = true
+        pipView.backgroundColor = .black
+
+        if let webView = view.subviews.first(where: { $0 is WKWebView || $0 is UIWebView }) {
+            view.insertSubview(pipView, belowSubview: webView)
+        } else {
+            view.addSubview(pipView)
+        }
+    }
+
+    private func setupFrontPreviewLayer(session: AVCaptureMultiCamSession) {
+        guard let pipView = self.pipView else { return }
+
+        frontPreviewLayer = AVCaptureVideoPreviewLayer(session: session)
+        frontPreviewLayer?.videoGravity = .resizeAspectFill
+        frontPreviewLayer?.frame = pipView.bounds
+
+        if let frontLayer = frontPreviewLayer {
+            pipView.layer.addSublayer(frontLayer)
+        }
+    }
+}

--- a/src/ios/DualCameraRenderController.swift
+++ b/src/ios/DualCameraRenderController.swift
@@ -59,21 +59,10 @@ class DualCameraRenderController {
         
         let orientation = UIDevice.current.orientation
         let isLandscape = orientation == .landscapeLeft || orientation == .landscapeRight
+        pipView.frame = CGRect(x: 16, y: 60, width: 160, height: 240)
         
         if isLandscape {
-            let pipWidth: CGFloat = 240
-            let pipHeight: CGFloat = 160
-            let pipX: CGFloat = 20
-            let pipY: CGFloat = 15
-            
-            pipView.frame = CGRect(x: pipX, y: pipY, width: pipWidth, height: pipHeight)
-        } else {
-            let pipWidth: CGFloat = 160
-            let pipHeight: CGFloat = 240
-            let pipX: CGFloat = 16
-            let pipY: CGFloat = 60
-            
-            pipView.frame = CGRect(x: pipX, y: pipY, width: pipWidth, height: pipHeight)
+            pipView.frame = CGRect(x: 20, y: 15, width: 240, height: 160)
         }
         
         frontPreviewLayer.frame = pipView.bounds
@@ -136,20 +125,11 @@ class DualCameraRenderController {
         let orientation = UIDevice.current.orientation
         let isLandscape = orientation == .landscapeLeft || orientation == .landscapeRight
         
-        let pipWidth: CGFloat
-        let pipHeight: CGFloat
-        let pipX: CGFloat = 16
-        let pipY: CGFloat = 60
-        
+        let pipView = UIView(frame: CGRect(x: 16, y: 60, width: 160, height: 240))
         if isLandscape {
-            pipWidth = 240
-            pipHeight = 160
-        } else {
-            pipWidth = 160
-            pipHeight = 240
+            let pipView = UIView(frame: CGRect(x: 16, y: 60, width: 240, height: 160))
         }
-
-        let pipView = UIView(frame: CGRect(x: pipX, y: pipY, width: pipWidth, height: pipHeight))
+        
         self.pipView = pipView
         pipView.layer.cornerRadius = 12
         pipView.clipsToBounds = true

--- a/src/ios/DualCameraSessionManager.swift
+++ b/src/ios/DualCameraSessionManager.swift
@@ -1,0 +1,378 @@
+import Foundation
+import AVFoundation
+
+protocol DualCameraSessionManagerDelegate: AnyObject {
+    func sessionManager(_ manager: DualCameraSessionManager, didOutput sampleBuffer: CMSampleBuffer, from output: AVCaptureOutput)
+}
+
+class DualCameraSessionManager: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAudioDataOutputSampleBufferDelegate {
+    let session = AVCaptureMultiCamSession()
+    private let queue = DispatchQueue(label: "dualMode.session.queue", qos: .userInitiated)
+    private(set) var backInput: AVCaptureDeviceInput?
+    private(set) var frontInput: AVCaptureDeviceInput?
+    private(set) var backOutput = AVCaptureVideoDataOutput()
+    private(set) var frontOutput = AVCaptureVideoDataOutput()
+    private(set) var backVideoPort: AVCaptureInput.Port?
+    private(set) var frontVideoPort: AVCaptureInput.Port?
+    private(set) var audioOutput: AVCaptureAudioDataOutput?
+    private(set) var audioInput: AVCaptureInput?
+    private var videoRecorder: VideoRecorder?
+    var videoMixer = VideoMixer()
+    private var latestBackBuffer: CMSampleBuffer?
+    private var latestFrontBuffer: CMSampleBuffer?
+    private let stateLock = NSLock()
+    private var _isConfiguring = false
+    private var _isSetupComplete = false
+    private var _isRecording = false
+    weak var delegate: DualCameraSessionManagerDelegate?
+
+    func setupSession(delegate: DualCameraSessionManagerDelegate, completion: @escaping (Bool) -> Void) {
+        self.delegate = delegate
+        queue.async { [weak self] in
+            guard let self = self else { 
+                DispatchQueue.main.async { completion(false) }
+                return 
+            }
+
+            self.isConfiguring = true
+            self.session.beginConfiguration()
+            var setupSuccess = true
+
+            defer { 
+                self.session.commitConfiguration()
+                self.isConfiguring = false
+                self.isSetupComplete = setupSuccess
+                DispatchQueue.main.async {
+                    completion(setupSuccess)
+                }
+            }
+
+            setupSuccess = self.setupBackCamera() && 
+                          self.setupFrontCamera() && 
+                          self.setupMicrophone()
+
+            if setupSuccess {
+                self.backOutput.setSampleBufferDelegate(self, queue: self.queue)
+                self.frontOutput.setSampleBufferDelegate(self, queue: self.queue)
+                if let audioOutput = self.audioOutput {
+                    audioOutput.setSampleBufferDelegate(self, queue: self.queue)
+                }
+            }
+        }
+    }
+
+    func startRecording(with recorder: VideoRecorder) {
+        queue.async { [weak self] in
+            guard let self = self else { return }
+
+            guard self.isReady() && !self.isRecording else {
+                print("Cannot start recording: session not ready or already recording")
+                return
+            }
+
+            self.videoRecorder = recorder
+            self.isRecording = true
+
+            // Lock the video mixer orientation at the start of recording
+            self.videoMixer.lockOrientation()
+
+            let isLandscape = UIDevice.current.orientation.isLandscape
+            if isLandscape {
+                self.videoMixer.pipFrame = CGRect(x: 0.03, y: 0.03, width: 0.25, height: 0.25)
+            } else {
+                self.videoMixer.pipFrame = CGRect(x: 0.05, y: 0.05, width: 0.3, height: 0.3)
+            }
+        }
+    }
+    
+    func stopRecording() {
+        queue.async { [weak self] in
+            guard let self = self else { return }
+  
+            // Unlock the video mixer orientation when recording stops
+            self.videoMixer.unlockOrientation()
+            
+            self.videoRecorder = nil
+            self.isRecording = false
+        }
+    }
+
+    func startSession() {
+        queue.async { [weak self] in
+            guard let self = self else { return }
+
+            if self.isSetupComplete && !self.isConfiguring && !self.session.isRunning {
+                self.session.startRunning()
+            }
+        }
+    }
+    
+    func isReady() -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return _isSetupComplete && !_isConfiguring
+    }
+
+    func stopSession() {
+        queue.async { [weak self] in
+            guard let self = self else { return }
+      
+            if self.isConfiguring {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    self.stopSession()
+                }
+                return
+            }
+            
+
+            if self.isRecording {
+                self.stopRecording()
+            }
+         
+            if self.session.isRunning {
+                self.session.stopRunning()
+            }
+        }
+    }
+
+    func updateVideoOrientation(_ orientation: AVCaptureVideoOrientation) {
+        // Don't change video orientation while recording
+        if isRecording {
+            return
+        }
+        
+        queue.async { [weak self] in
+            guard let self = self else { return }
+   
+            if let backConnection = self.backOutput.connection(with: .video) {
+                if backConnection.isVideoOrientationSupported {
+                    backConnection.videoOrientation = orientation
+                }
+            }
+            
+            if let frontConnection = self.frontOutput.connection(with: .video) {
+                if frontConnection.isVideoOrientationSupported {
+                    frontConnection.videoOrientation = orientation
+                }
+            }
+        }
+    }
+
+    private func setupBackCamera() -> Bool {
+        guard let backCamera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back),
+          let backInput = try? AVCaptureDeviceInput(device: backCamera),
+          session.canAddInput(backInput) else {
+        return false
+        }
+
+        configureCamera(backCamera, desiredWidth: 1920, desiredHeight: 1080)
+        self.backInput = backInput
+        session.addInputWithNoConnections(backInput)
+
+        if let port = backInput.ports.first(where: { $0.mediaType == .video }) {
+            self.backVideoPort = port
+        }
+
+        if session.canAddOutput(backOutput) {
+            backOutput.videoSettings = [
+                kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA)
+            ]
+            session.addOutputWithNoConnections(backOutput)
+
+            if let port = self.backVideoPort {
+                let connection = AVCaptureConnection(inputPorts: [port], output: backOutput)
+                connection.videoOrientation = getCurrentVideoOrientation()
+                session.addConnection(connection)
+            }
+        } else {
+            return false
+        }
+        return true
+    }
+    
+    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+
+        if let videoRecorder = self.videoRecorder, self.isRecording {
+            if output == backOutput {
+                self.latestBackBuffer = sampleBuffer
+            } else if output == frontOutput {
+                self.latestFrontBuffer = sampleBuffer
+            } else if output == audioOutput {
+                videoRecorder.appendAudioBuffer(sampleBuffer)
+                return
+            }
+
+            if self.videoMixer.inputFormatDescription == nil,
+               let formatDesc = CMSampleBufferGetFormatDescription(sampleBuffer) {
+                let orientationToUse = self.videoMixer.lockedOrientation ?? UIDevice.current.orientation
+                
+                let validOrientation: UIDeviceOrientation
+                switch orientationToUse {
+                case .portrait, .portraitUpsideDown, .landscapeLeft, .landscapeRight:
+                    validOrientation = orientationToUse
+                case .faceUp, .faceDown, .unknown:
+                    validOrientation = .portrait
+                @unknown default:
+                    validOrientation = .portrait
+                }
+                
+                let isLandscape = validOrientation.isLandscape
+                let targetWidth: Int32 = isLandscape ? 1920 : 1080
+                let targetHeight: Int32 = isLandscape ? 1080 : 1920
+                
+                self.videoMixer.prepare(with: formatDesc, outputRetainedBufferCountHint: 6, targetWidth: targetWidth, targetHeight: targetHeight)
+            }
+
+            guard let front = latestFrontBuffer, let back = latestBackBuffer else { return }
+
+            guard let frontBuffer = CMSampleBufferGetImageBuffer(front),
+                  let backBuffer = CMSampleBufferGetImageBuffer(back) else { return }
+
+            if let merged = self.videoMixer.mix(fullScreenPixelBuffer: backBuffer, pipPixelBuffer: frontBuffer, fullScreenPixelBufferIsFrontCamera: false) {
+                videoRecorder.appendVideoPixelBuffer(merged, withPresentationTime: CMSampleBufferGetPresentationTimeStamp(back))
+                latestFrontBuffer = nil
+                latestBackBuffer = nil
+            }
+        }
+
+        delegate?.sessionManager(self, didOutput: sampleBuffer, from: output)
+    }
+
+    private func setupFrontCamera() -> Bool {
+        guard let frontCamera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front),
+          let frontInput = try? AVCaptureDeviceInput(device: frontCamera),
+          session.canAddInput(frontInput) else {
+        return false
+        }
+
+        configureCamera(frontCamera, desiredWidth: 1920, desiredHeight: 1080)
+        self.frontInput = frontInput
+        session.addInputWithNoConnections(frontInput)
+
+        if let port = frontInput.ports.first(where: { $0.mediaType == .video }) {
+            self.frontVideoPort = port
+        }
+
+        if session.canAddOutput(frontOutput) {
+            frontOutput.videoSettings = [
+                kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA)
+            ]
+            session.addOutputWithNoConnections(frontOutput)
+
+            if let port = self.frontVideoPort {
+                let connection = AVCaptureConnection(inputPorts: [port], output: frontOutput)
+                connection.videoOrientation = getCurrentVideoOrientation()
+                connection.automaticallyAdjustsVideoMirroring = false
+                connection.isVideoMirrored = true
+                session.addConnection(connection)
+            }
+        } else {
+            return false
+        }
+        return true
+    }
+
+    private func setupMicrophone() -> Bool {
+        guard let mic = AVCaptureDevice.default(for: .audio),
+              let micInput = try? AVCaptureDeviceInput(device: mic),
+              session.canAddInput(micInput) else {
+            return false
+        }
+
+        self.audioInput = micInput
+        session.addInputWithNoConnections(micInput)
+
+        let audioOutput = AVCaptureAudioDataOutput()
+        if session.canAddOutput(audioOutput) {
+            session.addOutputWithNoConnections(audioOutput)
+
+            if let port = micInput.ports.first(where: { $0.mediaType == .audio }) {
+                let audioConnection = AVCaptureConnection(inputPorts: [port], output: audioOutput)
+                if session.canAddConnection(audioConnection) {
+                    session.addConnection(audioConnection)
+                }
+            }
+
+            self.audioOutput = audioOutput
+        } else {
+            return false
+        }
+        return true
+    }
+
+    private func configureCamera(_ device: AVCaptureDevice, desiredWidth: Int32, desiredHeight: Int32) {
+        for format in device.formats {
+            let description = format.formatDescription
+            let dimensions = CMVideoFormatDescriptionGetDimensions(description)
+            if dimensions.width == desiredWidth && dimensions.height == desiredHeight {
+                do {
+                    try device.lockForConfiguration()
+                    device.activeFormat = format
+                    device.unlockForConfiguration()
+                    print("Set \(device.localizedName) resolution to \(desiredWidth)x\(desiredHeight)")
+                    break
+                } catch {
+                    print("Error locking configuration for \(device.localizedName): \(error)")
+                }
+            }
+        }
+    }
+    
+    private func getCurrentVideoOrientation() -> AVCaptureVideoOrientation {
+        let orientation = UIDevice.current.orientation
+        switch orientation {
+        case .portrait:
+            return .portrait
+        case .portraitUpsideDown:
+            return .portraitUpsideDown
+        case .landscapeLeft:
+            return .landscapeRight
+        case .landscapeRight:
+            return .landscapeLeft
+        default:
+            return .portrait
+        }
+    }
+
+     private(set) var isConfiguring: Bool {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _isConfiguring
+        }
+
+        set {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            _isConfiguring = newValue
+        }
+    }
+    
+    private(set) var isSetupComplete: Bool {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _isSetupComplete
+        }
+
+        set {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            _isSetupComplete = newValue
+        }
+    }
+    
+    private var isRecording: Bool {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _isRecording
+        }
+
+        set {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            _isRecording = newValue
+        }
+    }
+}

--- a/src/ios/DualCameraSessionManager.swift
+++ b/src/ios/DualCameraSessionManager.swift
@@ -72,8 +72,6 @@ class DualCameraSessionManager: NSObject, AVCaptureVideoDataOutputSampleBufferDe
 
             self.videoRecorder = recorder
             self.isRecording = true
-
-            // Lock the video mixer orientation at the start of recording
             self.videoMixer.lockOrientation()
 
             let isLandscape = UIDevice.current.orientation.isLandscape
@@ -88,10 +86,7 @@ class DualCameraSessionManager: NSObject, AVCaptureVideoDataOutputSampleBufferDe
     func stopRecording() {
         queue.async { [weak self] in
             guard let self = self else { return }
-  
-            // Unlock the video mixer orientation when recording stops
             self.videoMixer.unlockOrientation()
-            
             self.videoRecorder = nil
             self.isRecording = false
         }
@@ -124,7 +119,6 @@ class DualCameraSessionManager: NSObject, AVCaptureVideoDataOutputSampleBufferDe
                 return
             }
             
-
             if self.isRecording {
                 self.stopRecording()
             }
@@ -136,7 +130,6 @@ class DualCameraSessionManager: NSObject, AVCaptureVideoDataOutputSampleBufferDe
     }
 
     func updateVideoOrientation(_ orientation: AVCaptureVideoOrientation) {
-        // Don't change video orientation while recording
         if isRecording {
             return
         }

--- a/src/ios/DualCameraSessionManager.swift
+++ b/src/ios/DualCameraSessionManager.swift
@@ -101,7 +101,7 @@ class DualCameraSessionManager: NSObject, AVCaptureVideoDataOutputSampleBufferDe
             }
         }
     }
-    
+
     func isReady() -> Bool {
         stateLock.lock()
         defer { stateLock.unlock() }
@@ -112,13 +112,6 @@ class DualCameraSessionManager: NSObject, AVCaptureVideoDataOutputSampleBufferDe
         queue.async { [weak self] in
             guard let self = self else { return }
       
-            if self.isConfiguring {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    self.stopSession()
-                }
-                return
-            }
-            
             if self.isRecording {
                 self.stopRecording()
             }
@@ -133,7 +126,7 @@ class DualCameraSessionManager: NSObject, AVCaptureVideoDataOutputSampleBufferDe
         if isRecording {
             return
         }
-        
+
         queue.async { [weak self] in
             guard let self = self else { return }
    

--- a/src/ios/VIdeoMixerShader.metal
+++ b/src/ios/VIdeoMixerShader.metal
@@ -1,3 +1,6 @@
+#include <metal_stdlib>
+using namespace metal;
+
 struct MixerParameters
 {
     float2 pipPosition;

--- a/src/ios/VIdeoMixerShader.metal
+++ b/src/ios/VIdeoMixerShader.metal
@@ -1,0 +1,36 @@
+struct MixerParameters
+{
+    float2 pipPosition;
+    float2 pipSize;
+};
+
+constant sampler kBilinearSampler(filter::linear,  coord::pixel, address::clamp_to_edge);
+
+// Compute kernel for picture-in-picture video mixing
+kernel void reporterMixer(texture2d<half, access::read>        fullScreenInput        [[ texture(0) ]],
+                          texture2d<half, access::sample>    pipInput            [[ texture(1) ]],
+                          texture2d<half, access::write>    outputTexture        [[ texture(2) ]],
+                          const device    MixerParameters&    mixerParameters        [[ buffer(0) ]],
+                          uint2 gid [[thread_position_in_grid]])
+
+{
+    uint2 pipPosition = uint2(mixerParameters.pipPosition);
+    uint2 pipSize = uint2(mixerParameters.pipSize);
+
+    half4 output;
+
+    // Check if the output pixel should be from full screen or PIP
+    if ( (gid.x >= pipPosition.x) && (gid.y >= pipPosition.y) &&
+         (gid.x < (pipPosition.x + pipSize.x)) && (gid.y < (pipPosition.y + pipSize.y)) )
+    {
+        // Position and scale the PIP window
+        float2 pipSamplingCoord =  float2(gid - pipPosition) * float2(pipInput.get_width(), pipInput.get_height()) / float2(pipSize);
+        output = pipInput.sample(kBilinearSampler, pipSamplingCoord + 0.5);
+    }
+    else
+    {
+        output = fullScreenInput.read(gid);
+    }
+
+    outputTexture.write(output, gid);
+}

--- a/src/ios/VideoMixer.swift
+++ b/src/ios/VideoMixer.swift
@@ -1,0 +1,304 @@
+import CoreMedia
+import CoreVideo
+
+class VideoMixer {
+    var description = "Video Mixer"
+    private(set) var isPrepared = false
+    var pipFrame = CGRect.zero
+    private(set) var inputFormatDescription: CMFormatDescription?
+    var outputFormatDescription: CMFormatDescription?
+    private var outputPixelBufferPool: CVPixelBufferPool?
+    private let metalDevice = MTLCreateSystemDefaultDevice()
+    private var textureCache: CVMetalTextureCache?
+    internal var lockedOrientation: UIDeviceOrientation?
+    private lazy var commandQueue: MTLCommandQueue? = {
+        guard let metalDevice = metalDevice else {
+            return nil
+        }
+        
+        return metalDevice.makeCommandQueue()
+    }()
+    
+    private var fullRangeVertexBuffer: MTLBuffer?
+    private var computePipelineState: MTLComputePipelineState?
+
+    init() {
+        guard let metalDevice = metalDevice,
+            let defaultLibrary = metalDevice.makeDefaultLibrary(),
+            let kernelFunction = defaultLibrary.makeFunction(name: "reporterMixer") else {
+                return
+        }
+        
+        do {
+            computePipelineState = try metalDevice.makeComputePipelineState(function: kernelFunction)
+        } catch {
+            print("Could not create compute pipeline state: \(error)")
+        }
+    }
+    
+    func prepare(with videoFormatDescription: CMFormatDescription, outputRetainedBufferCountHint: Int, targetWidth: Int32? = nil, targetHeight: Int32? = nil) {
+        reset()
+        
+        (outputPixelBufferPool, _, outputFormatDescription) = allocateOutputBufferPool(with: videoFormatDescription,
+                                                                                       outputRetainedBufferCountHint: outputRetainedBufferCountHint,
+                                                                                       targetWidth: targetWidth,
+                                                                                       targetHeight: targetHeight)
+        if outputPixelBufferPool == nil {
+            return
+        }
+        inputFormatDescription = videoFormatDescription
+        
+        guard let metalDevice = metalDevice else {
+                return
+        }
+        
+        var metalTextureCache: CVMetalTextureCache?
+        if CVMetalTextureCacheCreate(kCFAllocatorDefault, nil, metalDevice, nil, &metalTextureCache) != kCVReturnSuccess {
+            assertionFailure("Unable to allocate video mixer texture cache")
+        } else {
+            textureCache = metalTextureCache
+        }
+        
+        isPrepared = true
+    }
+    
+    func reset() {
+        outputPixelBufferPool = nil
+        outputFormatDescription = nil
+        inputFormatDescription = nil
+        textureCache = nil
+        lockedOrientation = nil
+        isPrepared = false
+    }
+    
+    func lockOrientation() {
+        let currentOrientation = UIDevice.current.orientation
+        
+        switch currentOrientation {
+        case .portrait, .portraitUpsideDown, .landscapeLeft, .landscapeRight:
+            lockedOrientation = currentOrientation
+        case .faceUp, .faceDown, .unknown:
+            lockedOrientation = .portrait
+        @unknown default:
+            lockedOrientation = .portrait
+        }
+    }
+    
+    func unlockOrientation() {
+        lockedOrientation = nil
+    }
+    
+    struct MixerParameters {
+        var pipPosition: SIMD2<Float>
+        var pipSize: SIMD2<Float>
+    }
+    
+    func mix(fullScreenPixelBuffer: CVPixelBuffer, pipPixelBuffer: CVPixelBuffer, fullScreenPixelBufferIsFrontCamera: Bool) -> CVPixelBuffer? {
+        guard isPrepared,
+            let outputPixelBufferPool = outputPixelBufferPool else {
+                assertionFailure("Invalid state: Not prepared")
+                return nil
+        }
+        
+        var newPixelBuffer: CVPixelBuffer?
+        CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, outputPixelBufferPool, &newPixelBuffer)
+        guard let outputPixelBuffer = newPixelBuffer else {
+            print("Allocation failure: Could not get pixel buffer from pool (\(self.description))")
+            return nil
+        }
+        
+        guard let outputTexture = makeTextureFromCVPixelBuffer(pixelBuffer: outputPixelBuffer),
+            let fullScreenTexture = makeTextureFromCVPixelBuffer(pixelBuffer: fullScreenPixelBuffer),
+            let pipTexture = makeTextureFromCVPixelBuffer(pixelBuffer: pipPixelBuffer) else {
+                return nil
+        }
+
+        let adjustedPipFrame = getAdjustedPipFrame(for: fullScreenTexture)
+        let pipPosition = SIMD2(Float(adjustedPipFrame.origin.x), Float(adjustedPipFrame.origin.y))
+        let pipSize = SIMD2(Float(adjustedPipFrame.size.width), Float(adjustedPipFrame.size.height))
+        var parameters = MixerParameters(pipPosition: pipPosition, pipSize: pipSize)
+        
+        guard let commandQueue = commandQueue,
+            let commandBuffer = commandQueue.makeCommandBuffer(),
+            let commandEncoder = commandBuffer.makeComputeCommandEncoder(),
+            let computePipelineState = computePipelineState else {
+                print("Failed to create Metal command encoder")
+                
+                if let textureCache = textureCache {
+                    CVMetalTextureCacheFlush(textureCache, 0)
+                }
+                
+                return nil
+        }
+        
+        commandEncoder.label = "PiP Video Mixer"
+        commandEncoder.setComputePipelineState(computePipelineState)
+        commandEncoder.setTexture(fullScreenTexture, index: 0)
+        commandEncoder.setTexture(pipTexture, index: 1)
+        commandEncoder.setTexture(outputTexture, index: 2)
+        withUnsafeMutablePointer(to: &parameters) { parametersRawPointer in
+            commandEncoder.setBytes(parametersRawPointer, length: MemoryLayout<MixerParameters>.size, index: 0)
+        }
+        
+        // Set up thread groups as described in https://developer.apple.com/reference/metal/mtlcomputecommandencoder
+        let width = computePipelineState.threadExecutionWidth
+        let height = computePipelineState.maxTotalThreadsPerThreadgroup / width
+        let threadsPerThreadgroup = MTLSizeMake(width, height, 1)
+        let threadgroupsPerGrid = MTLSize(width: (fullScreenTexture.width + width - 1) / width,
+                                          height: (fullScreenTexture.height + height - 1) / height,
+                                          depth: 1)
+        commandEncoder.dispatchThreadgroups(threadgroupsPerGrid, threadsPerThreadgroup: threadsPerThreadgroup)
+        
+        commandEncoder.endEncoding()
+        commandBuffer.commit()
+        
+        return outputPixelBuffer
+    }
+    
+    private func getAdjustedPipFrame(for fullScreenTexture: MTLTexture) -> CGRect {
+        let orientationToUse = lockedOrientation ?? UIDevice.current.orientation
+        
+        let validOrientation: UIDeviceOrientation
+        switch orientationToUse {
+        case .portrait, .portraitUpsideDown, .landscapeLeft, .landscapeRight:
+            validOrientation = orientationToUse
+        case .faceUp, .faceDown, .unknown:
+            validOrientation = .portrait
+        @unknown default:
+            validOrientation = .portrait
+        }
+        
+        let isLandscape = validOrientation.isLandscape
+        let textureWidth = Float(fullScreenTexture.width)
+        let textureHeight = Float(fullScreenTexture.height)
+        
+        if isLandscape {
+            let pipWidth = textureWidth * Float(pipFrame.size.width)
+            let pipHeight = textureHeight * Float(pipFrame.size.height)
+            let pipX = textureWidth * Float(pipFrame.origin.x)
+            let pipY = textureHeight * Float(pipFrame.origin.y)
+            
+            return CGRect(x: CGFloat(pipX), y: CGFloat(pipY), width: CGFloat(pipWidth), height: CGFloat(pipHeight))
+        } else {
+            let pipWidth = textureWidth * Float(pipFrame.size.width)
+            let pipHeight = textureHeight * Float(pipFrame.size.height)
+            let pipX = textureWidth * Float(pipFrame.origin.x)
+            let pipY = textureHeight * Float(pipFrame.origin.y)
+            
+            return CGRect(x: CGFloat(pipX), y: CGFloat(pipY), width: CGFloat(pipWidth), height: CGFloat(pipHeight))
+        }
+    }
+    
+    private func makeTextureFromCVPixelBuffer(pixelBuffer: CVPixelBuffer) -> MTLTexture? {
+        guard let textureCache = textureCache else {
+            print("No texture cache")
+            return nil
+        }
+        
+        let width = CVPixelBufferGetWidth(pixelBuffer)
+        let height = CVPixelBufferGetHeight(pixelBuffer)
+        
+        var cvTextureOut: CVMetalTexture?
+        CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault, textureCache, pixelBuffer, nil, .bgra8Unorm, width, height, 0, &cvTextureOut)
+        guard let cvTexture = cvTextureOut, let texture = CVMetalTextureGetTexture(cvTexture) else {
+            print("Video mixer failed to create preview texture")
+            
+            CVMetalTextureCacheFlush(textureCache, 0)
+            return nil
+        }
+        
+        return texture
+    }
+    
+    func allocateOutputBufferPool(with inputFormatDescription: CMFormatDescription, outputRetainedBufferCountHint: Int, targetWidth: Int32? = nil, targetHeight: Int32? = nil) -> (
+        outputBufferPool: CVPixelBufferPool?,
+        outputColorSpace: CGColorSpace?,
+        outputFormatDescription: CMFormatDescription?) {
+            
+            let inputMediaSubType = CMFormatDescriptionGetMediaSubType(inputFormatDescription)
+            if inputMediaSubType != kCVPixelFormatType_Lossy_32BGRA && inputMediaSubType != kCVPixelFormatType_Lossless_32BGRA &&
+                inputMediaSubType != kCVPixelFormatType_32BGRA {
+                assertionFailure("Invalid input pixel buffer type \(inputMediaSubType)")
+                return (nil, nil, nil)
+            }
+            
+            // Use target dimensions if provided, otherwise use input dimensions
+            let inputDimensions = CMVideoFormatDescriptionGetDimensions(inputFormatDescription)
+            let outputWidth = targetWidth ?? inputDimensions.width
+            let outputHeight = targetHeight ?? inputDimensions.height
+            
+            var pixelBufferAttributes: [String: Any] = [
+                kCVPixelBufferPixelFormatTypeKey as String: UInt(inputMediaSubType),
+                kCVPixelBufferWidthKey as String: Int(outputWidth),
+                kCVPixelBufferHeightKey as String: Int(outputHeight),
+                kCVPixelBufferIOSurfacePropertiesKey as String: [:]
+            ]
+            
+            // Get pixel buffer attributes and color space from the input format description
+            var cgColorSpace: CGColorSpace? = CGColorSpaceCreateDeviceRGB()
+            if let inputFormatDescriptionExtension = CMFormatDescriptionGetExtensions(inputFormatDescription) as Dictionary? {
+                let colorPrimaries = inputFormatDescriptionExtension[kCVImageBufferColorPrimariesKey]
+                
+                if let colorPrimaries = colorPrimaries {
+                    var colorSpaceProperties: [String: AnyObject] = [kCVImageBufferColorPrimariesKey as String: colorPrimaries]
+                    
+                    if let yCbCrMatrix = inputFormatDescriptionExtension[kCVImageBufferYCbCrMatrixKey] {
+                        colorSpaceProperties[kCVImageBufferYCbCrMatrixKey as String] = yCbCrMatrix
+                    }
+                    
+                    if let transferFunction = inputFormatDescriptionExtension[kCVImageBufferTransferFunctionKey] {
+                        colorSpaceProperties[kCVImageBufferTransferFunctionKey as String] = transferFunction
+                    }
+                    
+                    pixelBufferAttributes[kCVBufferPropagatedAttachmentsKey as String] = colorSpaceProperties
+                }
+                
+                if let cvColorspace = inputFormatDescriptionExtension[kCVImageBufferCGColorSpaceKey],
+                    CFGetTypeID(cvColorspace) == CGColorSpace.typeID {
+                    cgColorSpace = (cvColorspace as! CGColorSpace)
+                } else if (colorPrimaries as? String) == (kCVImageBufferColorPrimaries_P3_D65 as String) {
+                    cgColorSpace = CGColorSpace(name: CGColorSpace.displayP3)
+                }
+            }
+            
+            // Create a pixel buffer pool with the same pixel attributes as the input format description.
+            let poolAttributes = [kCVPixelBufferPoolMinimumBufferCountKey as String: outputRetainedBufferCountHint]
+            var cvPixelBufferPool: CVPixelBufferPool?
+            CVPixelBufferPoolCreate(kCFAllocatorDefault, poolAttributes as NSDictionary?, pixelBufferAttributes as NSDictionary?, &cvPixelBufferPool)
+            guard let pixelBufferPool = cvPixelBufferPool else {
+                assertionFailure("Allocation failure: Could not allocate pixel buffer pool.")
+                return (nil, nil, nil)
+            }
+            
+            preallocateBuffers(pool: pixelBufferPool, allocationThreshold: outputRetainedBufferCountHint)
+            
+            // Get the output format description
+            var pixelBuffer: CVPixelBuffer?
+            var outputFormatDescription: CMFormatDescription?
+            let auxAttributes = [kCVPixelBufferPoolAllocationThresholdKey as String: outputRetainedBufferCountHint] as NSDictionary
+            CVPixelBufferPoolCreatePixelBufferWithAuxAttributes(kCFAllocatorDefault, pixelBufferPool, auxAttributes, &pixelBuffer)
+            if let pixelBuffer = pixelBuffer {
+                CMVideoFormatDescriptionCreateForImageBuffer(allocator: kCFAllocatorDefault,
+                                                             imageBuffer: pixelBuffer,
+                                                             formatDescriptionOut: &outputFormatDescription)
+            }
+            pixelBuffer = nil
+            
+            return (pixelBufferPool, cgColorSpace, outputFormatDescription)
+    }
+    
+    private func preallocateBuffers(pool: CVPixelBufferPool, allocationThreshold: Int) {
+        var pixelBuffers = [CVPixelBuffer]()
+        var error: CVReturn = kCVReturnSuccess
+        let auxAttributes = [kCVPixelBufferPoolAllocationThresholdKey as String: allocationThreshold] as NSDictionary
+        var pixelBuffer: CVPixelBuffer?
+        while error == kCVReturnSuccess {
+            error = CVPixelBufferPoolCreatePixelBufferWithAuxAttributes(kCFAllocatorDefault, pool, auxAttributes, &pixelBuffer)
+            if let pixelBuffer = pixelBuffer {
+                pixelBuffers.append(pixelBuffer)
+            }
+            pixelBuffer = nil
+        }
+        pixelBuffers.removeAll()
+    }
+}

--- a/src/ios/VideoMixer.swift
+++ b/src/ios/VideoMixer.swift
@@ -46,6 +46,7 @@ class VideoMixer {
         if outputPixelBufferPool == nil {
             return
         }
+
         inputFormatDescription = videoFormatDescription
         
         guard let metalDevice = metalDevice else {
@@ -73,7 +74,6 @@ class VideoMixer {
     
     func lockOrientation() {
         let currentOrientation = UIDevice.current.orientation
-        
         switch currentOrientation {
         case .portrait, .portraitUpsideDown, .landscapeLeft, .landscapeRight:
             lockedOrientation = currentOrientation
@@ -83,7 +83,7 @@ class VideoMixer {
             lockedOrientation = .portrait
         }
     }
-    
+
     func unlockOrientation() {
         lockedOrientation = nil
     }
@@ -106,7 +106,7 @@ class VideoMixer {
             print("Allocation failure: Could not get pixel buffer from pool (\(self.description))")
             return nil
         }
-        
+
         guard let outputTexture = makeTextureFromCVPixelBuffer(pixelBuffer: outputPixelBuffer),
             let fullScreenTexture = makeTextureFromCVPixelBuffer(pixelBuffer: fullScreenPixelBuffer),
             let pipTexture = makeTextureFromCVPixelBuffer(pixelBuffer: pipPixelBuffer) else {

--- a/src/ios/VideoRecorder.swift
+++ b/src/ios/VideoRecorder.swift
@@ -1,0 +1,240 @@
+import Foundation
+import AVFoundation
+import UIKit
+
+class VideoRecorder {
+    private var assetWriter: AVAssetWriter?
+    private var videoInput: AVAssetWriterInput?
+    private var audioInput: AVAssetWriterInput?
+    private var adaptor: AVAssetWriterInputPixelBufferAdaptor?
+    private var startTime: CMTime?
+    private var outputURL: URL?
+    private var completionHandler: ((String, String?, Error?) -> Void)?
+    private let writerQueue = DispatchQueue(label: "video.recorder.queue", qos: .userInitiated)
+    private let stateLock = NSLock()
+    private var _isWriting = false
+
+    func startWriting(audioEnabled: Bool, recordingOrientation: UIDeviceOrientation? = nil, completion: @escaping (Error?) -> Void) {
+        writerQueue.async { [weak self] in
+            guard let self = self else {
+                completion(NSError(domain: "VideoRecorder", code: 1000, userInfo: [NSLocalizedDescriptionKey: "VideoRecorder deallocated"]))
+                return
+            }
+
+            guard !self.isWriting else {
+                completion(NSError(domain: "VideoRecorder", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Already writing"]))
+                return
+            }
+
+            do {
+                let outputDirectory = try FileManager.default.url(
+                    for: .libraryDirectory,
+                    in: .userDomainMask,
+                    appropriateFor: nil,
+                    create: true
+                ).appendingPathComponent("NoCloud", isDirectory: true)
+
+                try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+
+                let fileName = UUID().uuidString + ".mov"
+                self.outputURL = outputDirectory.appendingPathComponent(fileName)
+                self.assetWriter = try AVAssetWriter(outputURL: self.outputURL!, fileType: .mov)
+                
+                // Use provided orientation or fall back to current device orientation
+                let orientationToUse = recordingOrientation ?? UIDevice.current.orientation
+                
+                // Ensure we use a valid orientation for recording
+                let validOrientation: UIDeviceOrientation
+                switch orientationToUse {
+                case .portrait, .portraitUpsideDown, .landscapeLeft, .landscapeRight:
+                    validOrientation = orientationToUse
+                case .faceUp, .faceDown, .unknown:
+                    validOrientation = .portrait
+                @unknown default:
+                    validOrientation = .portrait
+                }
+                
+                let isLandscape = validOrientation.isLandscape
+                let videoWidth = isLandscape ? 1920 : 1080
+                let videoHeight = isLandscape ? 1080 : 1920
+
+                let videoSettings: [String: Any] = [
+                    AVVideoCodecKey: AVVideoCodecType.h264,
+                    AVVideoWidthKey: videoWidth,
+                    AVVideoHeightKey: videoHeight
+                ]
+
+                self.videoInput = AVAssetWriterInput(mediaType: .video, outputSettings: videoSettings)
+                self.videoInput?.expectsMediaDataInRealTime = true
+
+                let sourcePixelBufferAttributes: [String: Any] = [
+                    kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA),
+                    kCVPixelBufferWidthKey as String: videoWidth,
+                    kCVPixelBufferHeightKey as String: videoHeight
+                ]
+
+                self.adaptor = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput: self.videoInput!, sourcePixelBufferAttributes: sourcePixelBufferAttributes)
+
+                guard let writer = self.assetWriter, let vInput = self.videoInput else {
+                    completion(NSError(domain: "VideoRecorder", code: 1002, userInfo: [NSLocalizedDescriptionKey: "Failed to initialize AVAssetWriter"]))
+                    return
+                }
+
+                if writer.canAdd(vInput) {
+                    writer.add(vInput)
+                }
+
+                if audioEnabled {
+                    let audioSettings: [String: Any] = [
+                        AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+                        AVNumberOfChannelsKey: 1,
+                        AVSampleRateKey: 44100,
+                        AVEncoderBitRateKey: 64000
+                    ]
+
+                    self.audioInput = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings)
+                    self.audioInput?.expectsMediaDataInRealTime = true
+
+                    if let aInput = self.audioInput, writer.canAdd(aInput) {
+                        writer.add(aInput)
+                    }
+                }
+                
+                print("VideoRecorder: Writer initialized at \(self.outputURL!.path)")
+                self.isWriting = true
+                self.completionHandler = nil
+                
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
+
+            } catch {
+                DispatchQueue.main.async {
+                    completion(error)
+                }
+            }
+        }
+    }
+
+    func appendVideoPixelBuffer(_ pixelBuffer: CVPixelBuffer, withPresentationTime presentationTime: CMTime) {
+        writerQueue.async { [weak self] in
+            guard let self = self else { return }
+            
+            guard self.isWriting,
+                  let writer = self.assetWriter,
+                  writer.status == .unknown || writer.status == .writing,
+                  let vInput = self.videoInput,
+                  let adaptor = self.adaptor else { return }
+
+            if writer.status == .unknown {
+                writer.startWriting()
+                writer.startSession(atSourceTime: presentationTime)
+                self.startTime = presentationTime
+            }
+
+            if vInput.isReadyForMoreMediaData {
+                adaptor.append(pixelBuffer, withPresentationTime: presentationTime)
+            }
+        }
+    }
+
+    func appendAudioBuffer(_ sampleBuffer: CMSampleBuffer) {
+        writerQueue.async { [weak self] in
+            guard let self = self else { return }
+            
+            guard self.isWriting,
+                  let aInput = self.audioInput,
+                  aInput.isReadyForMoreMediaData,
+                  let writer = self.assetWriter,
+                  writer.status == .writing else { return }
+
+            aInput.append(sampleBuffer)
+        }
+    }
+
+    func stopWriting(completion: @escaping (String, String?, Error?) -> Void) {
+        writerQueue.async { [weak self] in
+            guard let self = self else {
+                completion("", nil, NSError(domain: "VideoRecorder", code: 1000, userInfo: [NSLocalizedDescriptionKey: "VideoRecorder deallocated"]))
+                return
+            }
+            
+            guard self.isWriting, let writer = self.assetWriter else {
+                completion("", nil, NSError(domain: "VideoRecorder", code: 1003, userInfo: [NSLocalizedDescriptionKey: "Recording was not started"]))
+                return
+            }
+
+            self.isWriting = false
+            self.completionHandler = completion
+
+            self.videoInput?.markAsFinished()
+            self.audioInput?.markAsFinished()
+
+            writer.finishWriting { [weak self] in
+                guard let self = self else { return }
+
+                if let error = writer.error {
+                    DispatchQueue.main.async {
+                        self.completionHandler?("", nil, error)
+                    }
+                    return
+                }
+
+                guard let videoPath = self.outputURL?.path else {
+                    DispatchQueue.main.async {
+                        self.completionHandler?("", nil, NSError(domain: "VideoRecorder", code: 1004, userInfo: [NSLocalizedDescriptionKey: "No video file path"]))
+                    }
+                    return
+                }
+
+                self.generateThumbnail(from: URL(fileURLWithPath: videoPath)) { thumbnailPath in
+                    DispatchQueue.main.async {
+                        self.completionHandler?(videoPath, thumbnailPath, nil)
+                    }
+                }
+            }
+        }
+    }
+
+    private func generateThumbnail(from url: URL, completion: @escaping (String?) -> Void) {
+        let asset = AVAsset(url: url)
+        let imageGenerator = AVAssetImageGenerator(asset: asset)
+        imageGenerator.appliesPreferredTrackTransform = true
+        let time = CMTime(seconds: 1.0, preferredTimescale: 600)
+
+        DispatchQueue.global().async {
+            do {
+                let cgImage = try imageGenerator.copyCGImage(at: time, actualTime: nil)
+                let uiImage = UIImage(cgImage: cgImage)
+                if let data = uiImage.jpegData(compressionQuality: 0.8) {
+                    let thumbName = UUID().uuidString + "video_thumb_.jpg"
+                    let dir = try FileManager.default.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+                        .appendingPathComponent("NoCloud", isDirectory: true)
+
+                    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+                    let fileURL = dir.appendingPathComponent(thumbName)
+                    try data.write(to: fileURL)
+                    completion(fileURL.path)
+                } else {
+                    completion(nil)
+                }
+            } catch {
+                print("Thumbnail generation failed: \(error)")
+                completion(nil)
+            }
+        }
+    }
+
+    private var isWriting: Bool {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _isWriting
+        }
+        set {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            _isWriting = newValue
+        }
+    }
+}

--- a/src/ios/VideoRecorder.swift
+++ b/src/ios/VideoRecorder.swift
@@ -39,11 +39,8 @@ class VideoRecorder {
                 let fileName = UUID().uuidString + ".mov"
                 self.outputURL = outputDirectory.appendingPathComponent(fileName)
                 self.assetWriter = try AVAssetWriter(outputURL: self.outputURL!, fileType: .mov)
-                
-                // Use provided orientation or fall back to current device orientation
                 let orientationToUse = recordingOrientation ?? UIDevice.current.orientation
                 
-                // Ensure we use a valid orientation for recording
                 let validOrientation: UIDeviceOrientation
                 switch orientationToUse {
                 case .portrait, .portraitUpsideDown, .landscapeLeft, .landscapeRight:
@@ -231,6 +228,7 @@ class VideoRecorder {
             defer { stateLock.unlock() }
             return _isWriting
         }
+
         set {
             stateLock.lock()
             defer { stateLock.unlock() }

--- a/www/DualCameraPreview.js
+++ b/www/DualCameraPreview.js
@@ -17,8 +17,8 @@ DualCameraPreview.capture = function (onSuccess, onError) {
   exec(onSuccess, onError, PLUGIN_NAME, "capture", []);
 };
 
-DualCameraPreview.disableDual = function (onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "disableDual", []);
+DualCameraPreview.disable = function (onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "disable", []);
 };
 
 DualCameraPreview.initVideoCallback = function (onSuccess, onError, callback) {

--- a/www/DualCameraPreview.js
+++ b/www/DualCameraPreview.js
@@ -9,16 +9,16 @@ DualCameraPreview.deviceSupportDualMode = function (onSuccess, onError) {
   exec(onSuccess, onError, PLUGIN_NAME, "deviceSupportDualMode", []);
 };
 
-DualCameraPreview.enableDualMode = function (onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "enableDualMode", []);
+DualCameraPreview.enable = function (onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "enable", []);
 };
 
-DualCameraPreview.captureDual = function (onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "captureDual", []);
+DualCameraPreview.capture = function (onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "capture", []);
 };
 
-DualCameraPreview.disableDualMode = function (onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "disableDualMode", []);
+DualCameraPreview.disableDual = function (onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "disableDual", []);
 };
 
 DualCameraPreview.initVideoCallback = function (onSuccess, onError, callback) {
@@ -38,7 +38,7 @@ DualCameraPreview.initVideoCallback = function (onSuccess, onError, callback) {
         );
 }
 
-DualCameraPreview.startVideoCaptureDual = function (options, onSuccess, onError) {
+DualCameraPreview.startVideoCapture = function (options, onSuccess, onError) {
   if (!DualCameraPreview.videoCallback) {
     console.error("Call initVideoCallback first");
     onError("Call initVideoCallback first");
@@ -54,11 +54,11 @@ DualCameraPreview.startVideoCaptureDual = function (options, onSuccess, onError)
   options = options || {};
   options.recordWithAudio = options.recordWithAudio != null ? options.recordWithAudio : true;
   options.videoDurationMs = options.videoDurationMs != null ? options.videoDurationMs : 3000;
-  exec(onSuccess, onError, PLUGIN_NAME, "startVideoCaptureDual", [options]);
+  exec(onSuccess, onError, PLUGIN_NAME, "startVideoCapture", [options]);
 };
 
-DualCameraPreview.stopVideoCaptureDual = function (onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "stopVideoCaptureDual");
+DualCameraPreview.stopVideoCapture = function (onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "stopVideoCapture");
 };
 
 module.exports = DualCameraPreview;

--- a/www/DualCameraPreview.js
+++ b/www/DualCameraPreview.js
@@ -13,9 +13,9 @@ DualCameraPreview.enableDualMode = function (onSuccess, onError) {
   exec(onSuccess, onError, PLUGIN_NAME, "enableDualMode", []);
 };
 
-DualCameraPreview.captureDual = function (options, onSuccess, onError) {
+DualCameraPreview.captureDual = function (onSuccess, onError) {
   options = options || {};
-  exec(onSuccess, onError, PLUGIN_NAME, "captureDual", [options.flash]);
+  exec(onSuccess, onError, PLUGIN_NAME, "captureDual");
 };
 
 DualCameraPreview.disableDualMode = function (onSuccess, onError) {

--- a/www/DualCameraPreview.js
+++ b/www/DualCameraPreview.js
@@ -14,8 +14,7 @@ DualCameraPreview.enableDualMode = function (onSuccess, onError) {
 };
 
 DualCameraPreview.captureDual = function (onSuccess, onError) {
-  options = options || {};
-  exec(onSuccess, onError, PLUGIN_NAME, "captureDual");
+  exec(onSuccess, onError, PLUGIN_NAME, "captureDual", []);
 };
 
 DualCameraPreview.disableDualMode = function (onSuccess, onError) {

--- a/www/DualCameraPreview.js
+++ b/www/DualCameraPreview.js
@@ -1,0 +1,65 @@
+var exec = require("cordova/exec");
+var PLUGIN_NAME = "DualCameraPreview";
+var DualCameraPreview = function () {};
+
+DualCameraPreview.videoInitialized = false;
+DualCameraPreview.videoCallback = null;
+
+DualCameraPreview.deviceSupportDualMode = function (onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "deviceSupportDualMode", []);
+};
+
+DualCameraPreview.enableDualMode = function (onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "enableDualMode", []);
+};
+
+DualCameraPreview.captureDual = function (options, onSuccess, onError) {
+  options = options || {};
+  exec(onSuccess, onError, PLUGIN_NAME, "captureDual", [options.flash]);
+};
+
+DualCameraPreview.disableDualMode = function (onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "disableDualMode", []);
+};
+
+DualCameraPreview.initVideoCallback = function (onSuccess, onError, callback) {
+    this.videoCallback = callback;
+    exec(
+            (info) => {
+              if (info.videoCallbackInitialized) {
+                DualCameraPreview.videoInitialized = true;
+                onSuccess();
+              }
+              this.videoCallback(info);
+            } ,
+            onError,
+            PLUGIN_NAME,
+            "initVideoCallback",
+            []
+        );
+}
+
+DualCameraPreview.startVideoCaptureDual = function (options, onSuccess, onError) {
+  if (!DualCameraPreview.videoCallback) {
+    console.error("Call initVideoCallback first");
+    onError("Call initVideoCallback first");
+    return;
+  }
+
+  if (!DualCameraPreview.videoInitialized) {
+    console.error("videoCallback not initialized");
+    onError("videoCallback not initialized");
+    return;
+  }
+  
+  options = options || {};
+  options.recordWithAudio = options.recordWithAudio != null ? options.recordWithAudio : true;
+  options.videoDurationMs = options.videoDurationMs != null ? options.videoDurationMs : 3000;
+  exec(onSuccess, onError, PLUGIN_NAME, "startVideoCaptureDual", [options]);
+};
+
+DualCameraPreview.stopVideoCaptureDual = function (onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "stopVideoCaptureDual");
+};
+
+module.exports = DualCameraPreview;

--- a/www/DualCameraPreview.js
+++ b/www/DualCameraPreview.js
@@ -22,20 +22,20 @@ DualCameraPreview.disable = function (onSuccess, onError) {
 };
 
 DualCameraPreview.initVideoCallback = function (onSuccess, onError, callback) {
-    this.videoCallback = callback;
-    exec(
-            (info) => {
-              if (info.videoCallbackInitialized) {
-                DualCameraPreview.videoInitialized = true;
-                onSuccess();
-              }
-              this.videoCallback(info);
-            } ,
-            onError,
-            PLUGIN_NAME,
-            "initVideoCallback",
-            []
-        );
+  this.videoCallback = callback;
+  exec(
+      (info) => {
+        if (info.videoCallbackInitialized) {
+          DualCameraPreview.videoInitialized = true;
+          onSuccess();
+        }
+        this.videoCallback(info);
+      } ,
+      onError,
+      PLUGIN_NAME,
+      "initVideoCallback",
+      []
+  );
 }
 
 DualCameraPreview.startVideoCapture = function (options, onSuccess, onError) {

--- a/www/dual-mode-plugin.js
+++ b/www/dual-mode-plugin.js
@@ -1,5 +1,0 @@
-var exec = require("cordova/exec");
-var PLUGIN_NAME = "DualCameraPreview";
-
-
-module.exports = dualCameraPreview;


### PR DESCRIPTION
This plugin introduces a Dual Camera Mode to the capture experience, allowing simultaneous use of both the front and rear cameras. Users can capture content from two perspectives at once, enabling creative compositions such as split-screen videos, picture-in-picture layouts.

In addition to dual photo capture, the plugin adds dual video recording, making it possible to record with both cameras in real time. This is especially useful for vloggers, interview scenarios, reaction videos, and multi-angle event coverage.

The plugin is built using Apple’s [AVCaptureMultiCamSession](https://developer.apple.com/documentation/avfoundation/avcapturemulticamsession?language=objc) API, ensuring high performance and efficient resource handling when streaming and recording from multiple cameras simultaneously.